### PR TITLE
Add double-click batch launchers (.bat files)

### DIFF
--- a/Install_Dependencies.bat
+++ b/Install_Dependencies.bat
@@ -1,0 +1,46 @@
+@echo off
+title PowerTrader AI - Install Dependencies
+cd /d "%~dp0"
+
+echo ============================================
+echo   PowerTrader AI - Dependency Installer
+echo ============================================
+echo.
+
+:: Check if Python is available
+python --version >nul 2>&1
+if %errorlevel% neq 0 (
+    echo Python was not found on your system!
+    echo Please install Python 3.10+ from:
+    echo https://www.python.org/downloads/
+    echo Make sure to check "Add Python to PATH"
+    echo.
+    pause
+    exit /b 1
+)
+
+echo Found Python:
+python --version
+echo.
+
+echo Upgrading pip...
+python -m pip install --upgrade pip
+echo.
+
+echo Installing required packages...
+python -m pip install -r requirements.txt
+echo.
+
+if %errorlevel% equ 0 (
+    echo ============================================
+    echo   All dependencies installed successfully!
+    echo   You can now run PowerTrader.bat
+    echo ============================================
+) else (
+    echo ============================================
+    echo   Some packages failed to install.
+    echo   Try running this file as Administrator.
+    echo ============================================
+)
+echo.
+pause

--- a/PowerTrader.bat
+++ b/PowerTrader.bat
@@ -1,0 +1,48 @@
+@echo off
+title PowerTrader AI
+cd /d "%~dp0"
+
+:: Check if Python is available
+python --version >nul 2>&1
+if %errorlevel% neq 0 (
+    echo ============================================
+    echo   Python was not found on your system!
+    echo   Please install Python 3.10+ from:
+    echo   https://www.python.org/downloads/
+    echo   Make sure to check "Add Python to PATH"
+    echo ============================================
+    pause
+    exit /b 1
+)
+
+:: Check if dependencies are installed by trying a quick import
+python -c "import requests, psutil, matplotlib, colorama, binance, kucoin" >nul 2>&1
+if %errorlevel% neq 0 (
+    echo Dependencies not found. Installing now...
+    echo.
+    python -m pip install -r requirements.txt
+    if %errorlevel% neq 0 (
+        echo.
+        echo ============================================
+        echo   Failed to install dependencies!
+        echo   Try running Install_Dependencies.bat
+        echo   as Administrator.
+        echo ============================================
+        pause
+        exit /b 1
+    )
+    echo.
+    echo Dependencies installed successfully!
+    echo.
+)
+
+echo ============================================
+echo   Starting PowerTrader AI Hub...
+echo ============================================
+echo.
+python pt_hub.py
+if %errorlevel% neq 0 (
+    echo.
+    echo PowerTrader AI exited with an error.
+    pause
+)

--- a/README.md
+++ b/README.md
@@ -75,7 +75,11 @@ IMPORTANT: This software places real trades automatically. You are responsible f
 
 ---
 
-## Step 3 — Install PowerTrader AI (one command)
+## Step 3 — Install PowerTrader AI
+
+**Easy way (no terminal needed):** Double-click **`Install_Dependencies.bat`** and wait for it to finish.
+
+**OR** do it manually with Command Prompt:
 
 1. Open **Command Prompt** (Windows key → type **cmd** → Enter).
 2. Go into your PowerTrader AI folder. Example:
@@ -94,11 +98,13 @@ IMPORTANT: This software places real trades automatically. You are responsible f
 
 ## Step 4 — Start PowerTrader AI
 
-From the same Command Prompt window (inside your PowerTrader folder), run:
+**Easy way (no terminal needed):** Double-click **`PowerTrader.bat`** — it will auto-install dependencies if needed and launch the Hub.
+
+**OR** from Command Prompt (inside your PowerTrader folder), run:
 
 `python pt_hub.py`
 
-The app that opens is the **PowerTrader Hub**.  
+The app that opens is the **PowerTrader Hub**.
 This is the only thing you need to run day-to-day.
 
 ---
@@ -171,6 +177,22 @@ A TRADE WILL START FOR A COIN IF THAT COIN REACHES A LONG LEVEL OF 3 OR HIGHER W
 3. Save
 4. Click **Train All**, wait for training to complete
 5. Click **Start All**
+
+---
+
+## Quick Launch Scripts (.bat files)
+
+For users who prefer not to use the terminal, the following batch files are included. Just double-click them!
+
+| File | What it does |
+|---|---|
+| **`PowerTrader.bat`** | Launches the PowerTrader Hub GUI. Auto-checks for Python and installs dependencies if missing. **This is the main one you need.** |
+| **`Install_Dependencies.bat`** | One-click installer for all required Python packages. Run this once on a fresh setup. |
+| **`Train_All.bat`** | Trains models for BTC and all other configured coins sequentially. |
+| **`Run_Thinker.bat`** | Launches the signal generator (pt_thinker) standalone. |
+| **`Run_Trader.bat`** | Launches the trade executor (pt_trader) standalone. Shows a warning before starting since it places real trades. |
+
+For day-to-day use, all you need is **`PowerTrader.bat`** — the Hub controls everything else.
 
 ---
 

--- a/Run_Thinker.bat
+++ b/Run_Thinker.bat
@@ -1,0 +1,15 @@
+@echo off
+title PowerTrader AI - Signal Generator
+cd /d "%~dp0"
+
+echo ============================================
+echo   PowerTrader AI - Signal Generator
+echo ============================================
+echo   (Press Ctrl+C to stop)
+echo.
+
+python pt_thinker.py
+
+echo.
+echo Signal generator stopped.
+pause

--- a/Run_Trader.bat
+++ b/Run_Trader.bat
@@ -1,0 +1,23 @@
+@echo off
+title PowerTrader AI - Trade Executor
+cd /d "%~dp0"
+
+echo ============================================
+echo   PowerTrader AI - Trade Executor
+echo ============================================
+echo.
+echo   WARNING: This will execute REAL trades
+echo   on your Binance account!
+echo.
+echo   Make sure b_key.txt and b_secret.txt
+echo   contain your Binance API credentials.
+echo.
+echo Press any key to start, or close this window to cancel.
+pause >nul
+echo.
+
+python pt_trader.py
+
+echo.
+echo Trade executor stopped.
+pause

--- a/Train_All.bat
+++ b/Train_All.bat
@@ -1,0 +1,36 @@
+@echo off
+title PowerTrader AI - Train All Coins
+cd /d "%~dp0"
+
+echo ============================================
+echo   PowerTrader AI - Train All Coins
+echo ============================================
+echo.
+echo This will train models for all configured
+echo coins sequentially. This can take a while.
+echo.
+echo Press any key to start, or close this window to cancel.
+pause >nul
+
+:: Train BTC (main folder)
+echo.
+echo [1] Training BTC...
+echo ----------------------------------------
+python pt_trainer.py BTC
+echo.
+
+:: Train each subfolder coin if it exists
+for /d %%D in (*) do (
+    if exist "%%D\pt_trainer.py" (
+        echo [+] Training %%D...
+        echo ----------------------------------------
+        python "%%D\pt_trainer.py" %%D
+        echo.
+    )
+)
+
+echo ============================================
+echo   Training complete for all coins!
+echo ============================================
+echo.
+pause


### PR DESCRIPTION
## Summary
- Added 5 `.bat` files so users can run PowerTrader AI by double-clicking instead of using the terminal
- `PowerTrader.bat` — main launcher that auto-checks Python and installs dependencies if missing
- `Install_Dependencies.bat` — one-click dependency installer
- `Train_All.bat` — trains all configured coins sequentially
- `Run_Thinker.bat` / `Run_Trader.bat` — standalone launchers for individual components
- Updated `README.md` with quick launch instructions and a table documenting all batch scripts

## Why
Makes the project more accessible to users who are not comfortable with the command line. No code changes — only adds `.bat` launcher scripts and updates the README.

## Test plan
- [ ] Double-click `Install_Dependencies.bat` on a fresh setup — should install all packages
- [ ] Double-click `PowerTrader.bat` — should launch the Hub GUI
- [ ] Verify `Train_All.bat`, `Run_Thinker.bat`, and `Run_Trader.bat` launch their respective scripts
- [ ] Verify README renders correctly on GitHub with the new sections